### PR TITLE
Add basic mysql schema

### DIFF
--- a/mysql/create_schema.sql
+++ b/mysql/create_schema.sql
@@ -6,7 +6,7 @@ USE `tess`;
 #
 # RANDOM_ID() generates a unique_id for tables that require them
 CREATE FUNCTION UNIQUE_ID ()
-	RETURNS CHAR(32) DETERMINISTIC
+    RETURNS CHAR(32) DETERMINISTIC
     RETURN CONCAT(HEX(RAND()*(~0>>1)),HEX(RAND()*(~0>>1)));
     
 #
@@ -15,12 +15,12 @@ CREATE FUNCTION UNIQUE_ID ()
 # Names of all the system supported by  this TESS instance
 #
 CREATE TABLE
-	IF NOT EXISTS `system` (
-		`system_id` INT NOT NULL AUTO_INCREMENT,
-		`name` VARCHAR(32) NOT NULL,
-		UNIQUE KEY `u_system_name` (`name` ASC),
-		PRIMARY KEY (`system_id` ASC)
-	)
+    IF NOT EXISTS `system` (
+        `system_id` INT NOT NULL AUTO_INCREMENT,
+        `name` VARCHAR(32) NOT NULL,
+        UNIQUE KEY `u_system_name` (`name` ASC),
+        PRIMARY KEY (`system_id` ASC)
+    )
     ENGINE=InnoDB 
     DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
@@ -30,14 +30,14 @@ CREATE TABLE
 # All resources for the current TESS instance.
 #
 CREATE TABLE
-	IF NOT EXISTS `resource` (
-		`resource_id` INT NOT NULL AUTO_INCREMENT,
+    IF NOT EXISTS `resource` (
+        `resource_id` INT NOT NULL AUTO_INCREMENT,
         `system_id` INT NOT NULL,
         `name` VARCHAR(32) NOT NULL,
         `quantity_unit` TEXT NOT NULL,
         `price_unit` TEXT NOT NULL,
         UNIQUE INDEX `u_resource_systemid_name` (`system_id` ASC, `name` ASC),
-		CONSTRAINT `fk_resource_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
+        CONSTRAINT `fk_resource_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
             ON DELETE CASCADE 
             ON UPDATE CASCADE,
         PRIMARY KEY (`resource_id` ASC)
@@ -51,15 +51,15 @@ CREATE TABLE
 # Users of the current TESS instance.
 #
 CREATE TABLE
-	IF NOT EXISTS `user` (
-		`user_id` INT NOT NULL AUTO_INCREMENT,
+    IF NOT EXISTS `user` (
+        `user_id` INT NOT NULL AUTO_INCREMENT,
         `system_id` INT NOT NULL,
         `name` VARCHAR(32) NOT NULL,
         `role` ENUM ('ADMINISTRATOR','OPERATOR','ACCOUNTING','CUSTOMER','TEST') NOT NULL,
         `email` TEXT NOT NULL,
         `sha1pwd` TEXT DEFAULT NULL,
         UNIQUE INDEX `u_user_systemid_name` (`system_id` ASC, `name` ASC),
-		CONSTRAINT `fk_user_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
+        CONSTRAINT `fk_user_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
             ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`user_id` ASC)
@@ -73,12 +73,12 @@ CREATE TABLE
 # User devices
 #
 CREATE TABLE
-	IF NOT EXISTS `device` (
-		`device_id` INT NOT NULL AUTO_INCREMENT,
+    IF NOT EXISTS `device` (
+        `device_id` INT NOT NULL AUTO_INCREMENT,
         `user_id` INT NOT NULL,
         `name` VARCHAR(32) NOT NULL,
         UNIQUE INDEX `u_device_deviceid_userid_name` (`device_id` ASC, `user_id` ASC, `name` ASC),
-		CONSTRAINT `fk_device_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+        CONSTRAINT `fk_device_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
             ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`device_id` ASC)
@@ -92,15 +92,15 @@ CREATE TABLE
 # User access tokens
 #
 CREATE TABLE
-	IF NOT EXISTS `token` (
-		`token_id` INT NOT NULL AUTO_INCREMENT,
+    IF NOT EXISTS `token` (
+        `token_id` INT NOT NULL AUTO_INCREMENT,
         `user_id` INT NOT NULL,
         `unique_id` VARCHAR(32) NOT NULL,
         `is_valid` ENUM ('False','True') DEFAULT 'True',
-		`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         UNIQUE INDEX `u_token_uniqueid` (`unique_id` ASC),
         INDEX `i_token_userid_created` (`user_id` ASC, `created` DESC),
-		CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+        CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
             ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`token_id` ASC)
@@ -108,11 +108,11 @@ CREATE TABLE
     ENGINE=InnoDB
     DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 CREATE 
-	DEFINER = CURRENT_USER 
-	TRIGGER `token_BEFORE_INSERT_1` 
-	BEFORE INSERT 
-	ON `token` FOR EACH ROW
-		SET NEW.`unique_id` = UNIQUE_ID();
+    DEFINER = CURRENT_USER 
+    TRIGGER `token_BEFORE_INSERT_1` 
+    BEFORE INSERT 
+    ON `token` FOR EACH ROW
+        SET NEW.`unique_id` = UNIQUE_ID();
 
 #
 # Contracts

--- a/mysql/create_schema.sql
+++ b/mysql/create_schema.sql
@@ -81,7 +81,7 @@ CREATE TABLE
 		CONSTRAINT `fk_device_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
             ON DELETE CASCADE 
             ON UPDATE RESTRICT,
-         PRIMARY KEY (`device_id` ASC)
+        PRIMARY KEY (`device_id` ASC)
    )
     ENGINE=InnoDB 
     DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
@@ -103,6 +103,9 @@ CREATE TABLE
             ON UPDATE RESTRICT,
         UNIQUE INDEX `u_token_uniqueid` (`unique_id` ASC),
         INDEX `i_token_userid_created` (`user_id` ASC, `created` DESC),
+        CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+            ON DELETE CASCADE 
+            ON UPDATE RESTRICT,
         PRIMARY KEY (`token_id` ASC)
     )
     ENGINE=InnoDB

--- a/mysql/create_schema.sql
+++ b/mysql/create_schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE
         UNIQUE INDEX `u_resource_systemid_name` (`system_id` ASC, `name` ASC),
 		CONSTRAINT `fk_resource_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
             ON DELETE CASCADE 
-            ON UPDATE RESTRICT,
+            ON UPDATE CASCADE,
         PRIMARY KEY (`resource_id` ASC)
     )
     ENGINE=InnoDB 
@@ -60,7 +60,7 @@ CREATE TABLE
         `sha1pwd` TEXT DEFAULT NULL,
         UNIQUE INDEX `u_user_systemid_name` (`system_id` ASC, `name` ASC),
 		CONSTRAINT `fk_user_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
-            ON DELETE CASCADE 
+            ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`user_id` ASC)
     )
@@ -79,7 +79,7 @@ CREATE TABLE
         `name` VARCHAR(32) NOT NULL,
         UNIQUE INDEX `u_device_deviceid_userid_name` (`device_id` ASC, `user_id` ASC, `name` ASC),
 		CONSTRAINT `fk_device_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
-            ON DELETE CASCADE 
+            ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`device_id` ASC)
    )
@@ -94,14 +94,14 @@ CREATE TABLE
 CREATE TABLE
 	IF NOT EXISTS `token` (
 		`token_id` INT NOT NULL AUTO_INCREMENT,
-        `user_id` INT,
+        `user_id` INT NOT NULL,
         `unique_id` VARCHAR(32) NOT NULL,
         `is_valid` ENUM ('False','True') DEFAULT 'True',
 		`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         UNIQUE INDEX `u_token_uniqueid` (`unique_id` ASC),
         INDEX `i_token_userid_created` (`user_id` ASC, `created` DESC),
 		CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
-            ON DELETE CASCADE 
+            ON DELETE RESTRICT 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`token_id` ASC)
     )
@@ -114,4 +114,22 @@ CREATE
 	ON `token` FOR EACH ROW
 		SET NEW.`unique_id` = UNIQUE_ID();
 
-
+#
+# Contracts
+#
+# Hyperledger contracts
+#
+CREATE TABLE
+    IF NOT EXISTS `contract` (
+        `contract_id` INT NOT NULL AUTO_INCREMENT,
+        `device_id` INT NOT NULL,
+        `hyperledger_id` VARCHAR(32) NOT NULL,
+        UNIQUE INDEX `u_contract_hyperledgerid` (`hyperledger_id` ASC),
+        INDEX `i_contract_deviceid` (`device_id` ASC),
+        CONSTRAINT `fk_contract_deviceid` FOREIGN KEY (`device_id`) REFERENCES `device` (`device_id`)
+            ON DELETE RESTRICT
+            ON UPDATE RESTRICT,
+        PRIMARY KEY (`contract_id` ASC)
+        )
+    ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/mysql/create_schema.sql
+++ b/mysql/create_schema.sql
@@ -1,0 +1,117 @@
+CREATE SCHEMA IF NOT EXISTS `tess`;
+USE `tess`;
+
+#
+# Functions
+#
+# RANDOM_ID() generates a unique_id for tables that require them
+CREATE FUNCTION UNIQUE_ID ()
+	RETURNS CHAR(32) DETERMINISTIC
+    RETURN CONCAT(HEX(RAND()*(~0>>1)),HEX(RAND()*(~0>>1)));
+    
+#
+# Systems
+#
+# Names of all the system supported by  this TESS instance
+#
+CREATE TABLE
+	IF NOT EXISTS `system` (
+		`system_id` INT NOT NULL AUTO_INCREMENT,
+		`name` VARCHAR(32) NOT NULL,
+		UNIQUE KEY `u_system_name` (`name` ASC),
+		PRIMARY KEY (`system_id` ASC)
+	)
+    ENGINE=InnoDB 
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+#
+# Resources
+#
+# All resources for the current TESS instance.
+#
+CREATE TABLE
+	IF NOT EXISTS `resource` (
+		`resource_id` INT NOT NULL AUTO_INCREMENT,
+        `system_id` INT NOT NULL,
+        `name` VARCHAR(32) NOT NULL,
+        `quantity_unit` TEXT NOT NULL,
+        `price_unit` TEXT NOT NULL,
+        UNIQUE INDEX `u_resource_systemid_name` (`system_id` ASC, `name` ASC),
+		CONSTRAINT `fk_resource_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
+            ON DELETE CASCADE 
+            ON UPDATE RESTRICT,
+        PRIMARY KEY (`resource_id` ASC)
+    )
+    ENGINE=InnoDB 
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+    
+#
+# Users
+#
+# Users of the current TESS instance.
+#
+CREATE TABLE
+	IF NOT EXISTS `user` (
+		`user_id` INT NOT NULL AUTO_INCREMENT,
+        `system_id` INT NOT NULL,
+        `name` VARCHAR(32) NOT NULL,
+        `role` ENUM ('ADMINISTRATOR','OPERATOR','ACCOUNTING','CUSTOMER','TEST') NOT NULL,
+        `email` TEXT NOT NULL,
+        `sha1pwd` TEXT DEFAULT NULL,
+        UNIQUE INDEX `u_user_systemid_name` (`system_id` ASC, `name` ASC),
+		CONSTRAINT `fk_user_systemid` FOREIGN KEY (`system_id`) REFERENCES `system` (`system_id`) 
+            ON DELETE CASCADE 
+            ON UPDATE RESTRICT,
+        PRIMARY KEY (`user_id` ASC)
+    )
+    ENGINE=InnoDB 
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+#
+# Devices
+#
+# User devices
+#
+CREATE TABLE
+	IF NOT EXISTS `device` (
+		`device_id` INT NOT NULL AUTO_INCREMENT,
+        `user_id` INT NOT NULL,
+        `name` VARCHAR(32) NOT NULL,
+        UNIQUE INDEX `u_device_deviceid_userid_name` (`device_id` ASC, `user_id` ASC, `name` ASC),
+		CONSTRAINT `fk_device_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+            ON DELETE CASCADE 
+            ON UPDATE RESTRICT,
+         PRIMARY KEY (`device_id` ASC)
+   )
+    ENGINE=InnoDB 
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+#
+# Tokens
+#
+# User access tokens
+#
+CREATE TABLE
+	IF NOT EXISTS `token` (
+		`token_id` INT NOT NULL AUTO_INCREMENT,
+        `user_id` INT,
+        `unique_id` VARCHAR(32) NOT NULL,
+        `is_valid` ENUM ('False','True') DEFAULT 'True',
+		`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+            ON DELETE CASCADE 
+            ON UPDATE RESTRICT,
+        UNIQUE INDEX `u_token_uniqueid` (`unique_id` ASC),
+        INDEX `i_token_userid_created` (`user_id` ASC, `created` DESC),
+        PRIMARY KEY (`token_id` ASC)
+    )
+    ENGINE=InnoDB
+    DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+CREATE 
+	DEFINER = CURRENT_USER 
+	TRIGGER `token_BEFORE_INSERT_1` 
+	BEFORE INSERT 
+	ON `token` FOR EACH ROW
+		SET NEW.`unique_id` = UNIQUE_ID();
+
+

--- a/mysql/create_schema.sql
+++ b/mysql/create_schema.sql
@@ -98,12 +98,9 @@ CREATE TABLE
         `unique_id` VARCHAR(32) NOT NULL,
         `is_valid` ENUM ('False','True') DEFAULT 'True',
 		`created` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-		CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
-            ON DELETE CASCADE 
-            ON UPDATE RESTRICT,
         UNIQUE INDEX `u_token_uniqueid` (`unique_id` ASC),
         INDEX `i_token_userid_created` (`user_id` ASC, `created` DESC),
-        CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
+		CONSTRAINT `fk_token_userid` FOREIGN KEY (`user_id`) REFERENCES `user` (`user_id`) 
             ON DELETE CASCADE 
             ON UPDATE RESTRICT,
         PRIMARY KEY (`token_id` ASC)

--- a/mysql/create_users.sql
+++ b/mysql/create_users.sql
@@ -12,18 +12,11 @@ CREATE USER 'tess_a'@'localhost' IDENTIFIED BY 'slacgismo';
 GRANT ALL ON `tess`.* TO 'tess_a'@'localhost';
 REVOKE DROP,DELETE ON `tess`.* FROM 'tess_a'@'localhost';
 
-# admin user access to test database
-GRANT ALL ON `test`.* TO 'tess_a'@'localhost';
-REVOKE DELETE ON `test`.* FROM 'tess_a'@'localhost';
-
 # regular user
 CREATE USER 'tess'@'localhost' IDENTIFIED BY 'slacgismo';
 
 # regular user access to TESS database
 GRANT SELECT,UPDATE,INSERT ON `tess`.* TO 'tess'@'localhost';
-
-# regular user access to test database
-GRANT SELECT,UPDATE,INSERT ON `test`.* TO 'tess'@'localhost';
 
 # all done
 FLUSH PRIVILEGES;

--- a/mysql/create_users.sql
+++ b/mysql/create_users.sql
@@ -22,28 +22,8 @@ CREATE USER 'tess'@'localhost' IDENTIFIED BY 'slacgismo';
 # regular user access to TESS database
 GRANT SELECT,UPDATE,INSERT ON `tess`.* TO 'tess'@'localhost';
 
-# cannot revoke these until the tables are created
--- REVOKE INSERT ON `tess`.`config` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`log` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`price` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`resource` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`setting` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`system` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`transaction` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `tess`.`user` FROM 'tess'@'localhost';
-
 # regular user access to test database
 GRANT SELECT,UPDATE,INSERT ON `test`.* TO 'tess'@'localhost';
-
-# cannot revoke these until the tables are created
--- REVOKE INSERT ON `test`.`config` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`log` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`price` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`resource` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`setting` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`system` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`transaction` FROM 'tess'@'localhost';
--- REVOKE INSERT ON `test`.`user` FROM 'tess'@'localhost';
 
 # all done
 FLUSH PRIVILEGES;

--- a/mysql/create_users.sql
+++ b/mysql/create_users.sql
@@ -1,0 +1,49 @@
+#
+# This script can only be run as root
+#
+
+# needed to allow functions to be created by admin
+SET GLOBAL log_bin_trust_function_creators = 1;
+
+# admin user
+CREATE USER 'tess_a'@'localhost' IDENTIFIED BY 'slacgismo';
+
+# admin user access to TESS database
+GRANT ALL ON `tess`.* TO 'tess_a'@'localhost';
+REVOKE DROP,DELETE ON `tess`.* FROM 'tess_a'@'localhost';
+
+# admin user access to test database
+GRANT ALL ON `test`.* TO 'tess_a'@'localhost';
+REVOKE DELETE ON `test`.* FROM 'tess_a'@'localhost';
+
+# regular user
+CREATE USER 'tess'@'localhost' IDENTIFIED BY 'slacgismo';
+
+# regular user access to TESS database
+GRANT SELECT,UPDATE,INSERT ON `tess`.* TO 'tess'@'localhost';
+
+# cannot revoke these until the tables are created
+-- REVOKE INSERT ON `tess`.`config` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`log` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`price` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`resource` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`setting` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`system` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`transaction` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `tess`.`user` FROM 'tess'@'localhost';
+
+# regular user access to test database
+GRANT SELECT,UPDATE,INSERT ON `test`.* TO 'tess'@'localhost';
+
+# cannot revoke these until the tables are created
+-- REVOKE INSERT ON `test`.`config` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`log` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`price` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`resource` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`setting` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`system` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`transaction` FROM 'tess'@'localhost';
+-- REVOKE INSERT ON `test`.`user` FROM 'tess'@'localhost';
+
+# all done
+FLUSH PRIVILEGES;

--- a/mysql/initialize_database.sql
+++ b/mysql/initialize_database.sql
@@ -46,8 +46,8 @@ SET @hce_feeder_id = LAST_INSERT_ID();
 #    
 INSERT INTO `tess`.`token` (`user_id`) VALUES
 	(@hce_admin_id),
-    (@hce_operator_id),
-    (@hce_accounting_id),
-    (@hce_testuser1_id),
-    (@hce_testuser2_id),
-    (@hce_testuser3_id);
+	(@hce_operator_id),
+	(@hce_accounting_id),
+	(@hce_testuser1_id),
+	(@hce_testuser2_id),
+	(@hce_testuser3_id);

--- a/mysql/initialize_database.sql
+++ b/mysql/initialize_database.sql
@@ -2,52 +2,52 @@
 # Create HCE system
 #
 INSERT INTO `tess`.`system` (`name`) VALUES
-	("HCE");
+    ("HCE");
 SET @hce_system_id = LAST_INSERT_ID();
 
 #
 # Define HCE capacity resource
 #
 INSERT INTO `tess`.`resource` (`system_id`,`name`,`quantity_unit`,`price_unit`) VALUES
-	(@hce_system_id,"capacity","MW","$/MWh");
+    (@hce_system_id,"capacity","MW","$/MWh");
 SET @hce_capacity_resource = LAST_INSERT_ID();
 
 #
 # Define HCE users `admin` and `operator`
 #
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"admin","ADMINISTRATOR","administrator@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"admin","ADMINISTRATOR","administrator@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_admin_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"operator","OPERATOR","operator@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"operator","OPERATOR","operator@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_operator_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"accounting","ACCOUNTING","accounting@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"accounting","ACCOUNTING","accounting@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_accounting_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser1","TEST","testuser1@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"testuser1","TEST","testuser1@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_testuser1_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser2","TEST","testuser2@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"testuser2","TEST","testuser2@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_testuser2_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser3","TEST","testuser3@holycross.com",SHA1('Sl@cG1sm0'));
+    (@hce_system_id,"testuser3","TEST","testuser3@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_testuser3_id = LAST_INSERT_ID();
 
 #
 # Define primary HCE feeder
 #
 INSERT INTO `tess`.`device` (`user_id`,`name`) VALUES
-	(1,"feeder");
+    (1,"feeder");
 SET @hce_feeder_id = LAST_INSERT_ID();
 
 #
 # Set the initial user access tokens
 #    
 INSERT INTO `tess`.`token` (`user_id`) VALUES
-	(@hce_admin_id),
-	(@hce_operator_id),
-	(@hce_accounting_id),
-	(@hce_testuser1_id),
-	(@hce_testuser2_id),
-	(@hce_testuser3_id);
+    (@hce_admin_id),
+    (@hce_operator_id),
+    (@hce_accounting_id),
+    (@hce_testuser1_id),
+    (@hce_testuser2_id),
+    (@hce_testuser3_id);

--- a/mysql/initialize_database.sql
+++ b/mysql/initialize_database.sql
@@ -1,0 +1,53 @@
+#
+# Create HCE system
+#
+INSERT INTO `tess`.`system` (`name`) VALUES
+	("HCE");
+SET @hce_system_id = LAST_INSERT_ID();
+
+#
+# Define HCE capacity resource
+#
+INSERT INTO `tess`.`resource` (`system_id`,`name`,`quantity_unit`,`price_unit`) VALUES
+	(@hce_system_id,"capacity","MW","$/MWh");
+SET @hce_capacity_resource = LAST_INSERT_ID();
+
+#
+# Define HCE users `admin` and `operator`
+#
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"admin","ADMINISTRATOR","administrator@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_admin_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"operator","OPERATOR","operator@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_operator_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"accounting","ACCOUNTING","accounting@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_operator_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"testuser1","TEST","testuser1@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_accounting_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"testuser2","TEST","testuser2@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_testuser1_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"testuser3","TEST","testuser3@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_testuser2_id = LAST_INSERT_ID();
+
+#
+# Define primary HCE feeder
+#
+INSERT INTO `tess`.`device` (`user_id`,`name`) VALUES
+	(1,"feeder");
+SET @hce_feeder_id = LAST_INSERT_ID();
+
+#
+# Set the initial user access tokens
+#    
+INSERT INTO `tess`.`token` (`user_id`) VALUES
+	(@hce_admin_id),
+    (@hce_operator_id),
+    (@hce_accounting_id),
+    (@hca_testuser1_id),
+    (@hce_testuser2_id),
+    (@hca_testuser3_id);

--- a/mysql/initialize_database.sql
+++ b/mysql/initialize_database.sql
@@ -23,16 +23,16 @@ INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
 SET @hce_operator_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
 	(@hce_system_id,"accounting","ACCOUNTING","accounting@holycross.com",SHA1('Sl@cG1sm0'));
-SET @hce_operator_id = LAST_INSERT_ID();
-INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser1","TEST","testuser1@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_accounting_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser2","TEST","testuser2@holycross.com",SHA1('Sl@cG1sm0'));
+	(@hce_system_id,"testuser1","TEST","testuser1@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_testuser1_id = LAST_INSERT_ID();
 INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
-	(@hce_system_id,"testuser3","TEST","testuser3@holycross.com",SHA1('Sl@cG1sm0'));
+	(@hce_system_id,"testuser2","TEST","testuser2@holycross.com",SHA1('Sl@cG1sm0'));
 SET @hce_testuser2_id = LAST_INSERT_ID();
+INSERT INTO `tess`.`user` (`system_id`,`name`,`role`,`email`,`sha1pwd`) VALUES
+	(@hce_system_id,"testuser3","TEST","testuser3@holycross.com",SHA1('Sl@cG1sm0'));
+SET @hce_testuser3_id = LAST_INSERT_ID();
 
 #
 # Define primary HCE feeder
@@ -48,6 +48,6 @@ INSERT INTO `tess`.`token` (`user_id`) VALUES
 	(@hce_admin_id),
     (@hce_operator_id),
     (@hce_accounting_id),
-    (@hca_testuser1_id),
+    (@hce_testuser1_id),
     (@hce_testuser2_id),
-    (@hca_testuser3_id);
+    (@hce_testuser3_id);


### PR DESCRIPTION
The PR closes issue #16.

Add support for static data tables only in schema `tess`:
- [x] `system`: main system identification (allows for multiple systems in a single database)
  - Fields: `system_id`, `name`
  - Primary key: `system_id`
  - Unique keys: `name`
  - Indexes: (none)
  - Constraint keys: (none)
- [x] `resource`: system resources managed by TESS
  - Fields: `resource_id`, `system_id`, `name`, `quantity_unit`, `price_unit`
  - Primary key: `resource_id`
  - Unique keys: `system_id`+`name`
  - Indexes: (none)
  - Constraint keys: `system_id`
- [x] `user`: people allowed access to TESS (by role)
  - Fields: `user_id`, `system_id`, `name`, `role`, `email`, `sha1pwd`
  - Primary key: `user_id`
  - Unique keys: 
  - Indexes: (none)
  - Constraint keys: `system_id`
- [x] `device`: devices allowed access to TESS
  - Fields: `device_id`, `user_id`, `name`
  - Primary key: `device_id`
  - Unique keys: `user_id`+`name`
  - Indexes: (none)
  - Constraint keys: `user_id`
- [x] `token`: user access tokens (given to devices and other agents to authenticate)
  - Fields: `token_id`, `user_id`, `unique_id`, `is_valid`, `created`
  - Primary key: `token_id`
  - Unique keys: `unique_id`
  - Indexes: `user_id`+`created`
  - Constraint keys: `user_id`
- [x] `contract`: hyperledger contracts for devices
  - Fields: `contract_id`, `device_id`, `hyperledger_id`
  - Primary key: `contract_id`
  - Indexes: `hyperledger_id`
  - Unique keys: (none)
  - Constraint keys: `device_id`
