### PR TITLE
Add web docker

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,5 +1,7 @@
 # This is where the web platform will live!
 
+# MacOS setup
+
 ## Creating the env
 ```bash
 conda create -n venv_tess python=3.8
@@ -50,3 +52,11 @@ export FLASK_APP=web
 flask run
 ```
 ... navigate to `localhost:5000`
+
+# Docker Compose
+
+## Bring up the docker image
+
+```bash
+docker-compose up
+```

--- a/web/db/init.sql
+++ b/web/db/init.sql
@@ -1,0 +1,4 @@
+CREATE USER 'tess_user'@'localhost' IDENTIFIED BY 'tess_db_password_local';
+FLUSH PRIVILEGES;
+
+CREATE DATABASE 'tess';

--- a/web/db/init.sql
+++ b/web/db/init.sql
@@ -1,4 +1,4 @@
 CREATE USER 'tess_user'@'localhost' IDENTIFIED BY 'tess_db_password_local';
 FLUSH PRIVILEGES;
 
-CREATE DATABASE 'tess';
+CREATE DATABASE `tess`;

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "2"
+services:
+  app:
+    build: ./web
+    links:
+      - db
+    ports:
+      - "5000:5000"
+
+  db:
+    image: mysql:5.7
+    ports:
+      - "32000:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    volumes:
+      - ./db:/docker-entrypoint-initdb.d/:ro

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "2"
 services:
-  web:
+  app:
     build: ./web
     links:
       - db

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "2"
 services:
-  app:
+  web:
     build: ./web
     links:
       - db

--- a/web/web/Dockerfile
+++ b/web/web/Dockerfile
@@ -1,9 +1,8 @@
 FROM conda/miniconda3-centos7
 
-WORKDIR /tmp
+WORKDIR /web
 
-COPY setup.sh /tmp/
-COPY requirements.txt /tmp/
+COPY . /web/
 
 RUN chmod +x *.sh
 RUN ./setup.sh

--- a/web/web/Dockerfile
+++ b/web/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM conda/miniconda3-centos7
+
+WORKDIR /tmp
+
+COPY setup.sh /tmp/
+COPY requirements.txt /tmp/
+
+RUN chmod +x *.sh
+RUN ./setup.sh
+
+EXPOSE 5000/tcp

--- a/web/web/requirements.txt
+++ b/web/web/requirements.txt
@@ -1,0 +1,6 @@
+flask==1.1.2
+Flask-SQLAlchemy==2.4.1
+Flask-Migrate==2.5.3
+Flask-Bcrypt==0.7.1
+PyMySQL==0.9.3
+cryptography==2.9.2

--- a/web/web/setup.sh
+++ b/web/web/setup.sh
@@ -4,5 +4,10 @@ conda create -n venv_tess python=3.8
 conda activate venv_tess
 pip install -r requirements.txt
 
+yum install net-tools -y
+IFCONF=$(ifconfig eth0 | grep inet)
+IPADDR=$(echo $IFCONF | cut -f2 -d' ')
+echo "To access this server, use http://$IPADDR:5000/"
+
 export FLASK_APP=/web
 flask run

--- a/web/web/setup.sh
+++ b/web/web/setup.sh
@@ -4,9 +4,5 @@ conda create -n venv_tess python=3.8
 conda activate venv_tess
 pip install -r requirements.txt
 
-PASSWORD=$(openssl rand -base64 20 | tr -cd 'A-Za-z0-9')
-mysqladmin -u root root "${PASSWORD:-root}"
-echo '*** 'MYSQL ROOT PASSWORD is ${PASSWORD:-root}' ***'
-
 export FLASK_APP=web
 flask run

--- a/web/web/setup.sh
+++ b/web/web/setup.sh
@@ -4,5 +4,5 @@ conda create -n venv_tess python=3.8
 conda activate venv_tess
 pip install -r requirements.txt
 
-export FLASK_APP=web
+export FLASK_APP=/web
 flask run

--- a/web/web/setup.sh
+++ b/web/web/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+conda create -n venv_tess python=3.8
+conda activate venv_tess
+pip install -r requirements.txt
+
+PASSWORD=$(openssl rand -base64 20 | tr -cd 'A-Za-z0-9')
+mysqladmin -u root root "${PASSWORD:-root}"
+echo '*** 'MYSQL ROOT PASSWORD is ${PASSWORD:-root}' ***'
+
+export FLASK_APP=web
+flask run


### PR DESCRIPTION
The PR address how to run the web app on docker.  The approach uses `docker-compose` by adding the required configuration files for the web app and the mysql server.

# Issues
* When `docker-compose up` is run, the app reports the IP address and port to use to connect, but the server does not respond.

# Files changed
- [x] Add matter related to using docker in `README.md`
- [x] Add `web/docker-compose.yml` to configure the docker system
- [x] Add `web/db/init.sql` to initialization MySQL server
- [x] Add `web/web/Dockerfile` to setup flask app
- [x] Add `web/web/setup.sh` to start the flask app
- [x] Add `web/web/requirements.txt` because `docker-compose` cannot reference the one in the `web` folder itself.

# Documentation changes
None

# Testing and validation notes
None