### PR TITLE
create rate api, add additional api methods

### DIFF
--- a/web/web/__init__.py
+++ b/web/web/__init__.py
@@ -33,6 +33,7 @@ from web.api.v1.market_interval import market_interval_api_bp
 from web.api.v1.channel import channel_api_bp
 from web.api.v1.alert_type import alert_types_api_bp
 from web.api.v1.role import role_api_bp
+from web.api.v1.rate import rate_api_bp
 
 
 def page_not_found(e):
@@ -95,6 +96,7 @@ def register_blueprints(app):
     app.register_blueprint(channel_api_bp, url_prefix='/api/v1/')
     app.register_blueprint(alert_types_api_bp, url_prefix='/api/v1/')
     app.register_blueprint(role_api_bp, url_prefix='/api/v1/')
+    app.register_blueprint(rate_api_bp, url_prefix='/api/v1/')
 
 
 if os.environ.get('FLASK_ENV', 'development') == 'production':

--- a/web/web/api/v1/address.py
+++ b/web/web/api/v1/address.py
@@ -47,7 +47,7 @@ def show_address_info(address_id):
 
 
 @address_api_bp.route('/address/<int:address_id>', methods=['PUT'])
-def modify_address():
+def modify_address(address_id):
     '''
     Updates one address object in database
     '''
@@ -70,7 +70,7 @@ def modify_address():
         db.session.rollback()
         return arw.to_json(None, 400)
 
-    results = address_schema.dump(modified_address, many=True)
+    results = address_schema.dump(modified_address)
 
     return arw.to_json(results)
 

--- a/web/web/api/v1/address.py
+++ b/web/web/api/v1/address.py
@@ -9,6 +9,72 @@ from web.models.address import Address, AddressSchema
 address_api_bp = Blueprint('address_api_bp', __name__)
 
 
+@address_api_bp.route('/addresses', methods=['GET'])
+def get_addresses():
+    '''
+    Retrieves all address objects
+    '''
+    arw = ApiResponseWrapper()
+
+    addresses = Address.query.all()
+    address_schema = AddressSchema()
+    results = address_schema.dump(addresses, many=True)
+
+    return arw.to_json(results)
+
+
+@address_api_bp.route('/address/<int:address_id>', methods=['GET'])
+def show_address_info(address_id):
+    '''
+    Retrieves one address object
+    '''
+
+    arw = ApiResponseWrapper()
+    address_schema = AddressSchema()
+
+    try:
+        address = Address.query.filter_by(address_id=address_id).one()
+
+    except (MultipleResultsFound, NoResultFound):
+        arw.add_errors('No result found or multiple results found')
+
+    if arw.has_errors():
+        return arw.to_json(None, 400)
+
+    results = address_schema.dump(address)
+
+    return arw.to_json(results)
+
+
+@address_api_bp.route('/address/<int:address_id>', methods=['PUT'])
+def modify_address():
+    '''
+    Updates one address object in database
+    '''
+    arw = ApiResponseWrapper()
+    address_schema = AddressSchema(exclude=['address_id'])
+    modified_address = request.get_json()
+
+    try:
+        modified_address = address_schema.load(modified_address,
+                                               session=db.session)
+        db.session.commit()
+
+    except ValidationError as ve:
+        arw.add_errors(ve.messages)
+
+    except IntegrityError:
+        arw.add_errors('Integrity error')
+
+    if arw.has_errors():
+        db.session.rollback()
+        return arw.to_json(None, 400)
+
+    results = address_schema.dump(modified_address, many=True)
+
+    return arw.to_json(results)
+
+
 @address_api_bp.route('/address', methods=['POST'])
 def add_address():
     '''

--- a/web/web/api/v1/address.py
+++ b/web/web/api/v1/address.py
@@ -52,7 +52,7 @@ def modify_address():
     Updates one address object in database
     '''
     arw = ApiResponseWrapper()
-    address_schema = AddressSchema(exclude=['address_id'])
+    address_schema = AddressSchema()
     modified_address = request.get_json()
 
     try:

--- a/web/web/api/v1/channel.py
+++ b/web/web/api/v1/channel.py
@@ -9,6 +9,28 @@ from web.models.channel import Channel, ChannelSchema
 channel_api_bp = Blueprint('channel_api_bp', __name__)
 
 
+@channel_api_bp.route('/channel/<int:channel_id>', methods=['GET'])
+def show_channel_info(channel_id):
+    '''
+    Retrieves one channel object
+    '''
+    arw = ApiResponseWrapper()
+    channel_schema = ChannelSchema()
+
+    try:
+        channel = Channel.query.filter_by(channel_id=channel_id).one()
+
+    except (MultipleResultsFound, NoResultFound):
+        arw.add_errors('No result found or multiple results found')
+
+    if arw.has_errors():
+        return arw.to_json(None, 400)
+
+    results = channel_schema.dump(channel)
+
+    return arw.to_json(results)
+
+
 @channel_api_bp.route('/channel', methods=['POST'])
 def add_channel():
     '''

--- a/web/web/api/v1/market.py
+++ b/web/web/api/v1/market.py
@@ -11,6 +11,33 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 market_api_bp = Blueprint('market_api_bp', __name__)
 
 
+@market_api_bp.route('/markets', methods=['GET'])
+def get_markets():
+    '''
+    Returns all market objects
+    '''
+
+    arw = ApiResponseWrapper()
+
+    fields_to_filter_on = request.args.getlist('fields')
+
+    if len(fields_to_filter_on) > 0:
+        for field in fields_to_filter_on:
+            if field not in Market.__table__.columns:
+                arw.add_errors({field: 'Invalid Market field'})
+                return arw.to_json(None, 400)
+    else:
+        fields_to_filter_on = None
+
+    market_schema = MarketSchema(only=fields_to_filter_on)
+
+    markets = Market.query.all()
+
+    results = market_schema.dump(markets, many=True)
+
+    return arw.to_json(results)
+
+
 @market_api_bp.route('/market/<int:market_id>', methods=['GET'])
 def show_market_info(market_id):
     '''

--- a/web/web/api/v1/meter.py
+++ b/web/web/api/v1/meter.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 meter_api_bp = Blueprint('meter_api_bp', __name__)
 
 
-@meter_api_bp.route('/meters/', methods=['GET'])
+@meter_api_bp.route('/meters', methods=['GET'])
 def get_meter_ids():
     '''
     Returns all meter objects

--- a/web/web/api/v1/pv.py
+++ b/web/web/api/v1/pv.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 pv_api_bp = Blueprint('pv_api_bp', __name__)
 
 
-@pv_api_bp.route('/pvs/', methods=['GET'])
+@pv_api_bp.route('/pvs', methods=['GET'])
 def get_pvs():
     '''
     Returns all pv objects

--- a/web/web/api/v1/rate.py
+++ b/web/web/api/v1/rate.py
@@ -4,7 +4,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from .response_wrapper import ApiResponseWrapper
 from web.database import db
-from web.models.rate import Rate, RateSchema
+from web.models.rate import Rate
+from web.models.meter_interval import RateSchema
 
 rate_api_bp = Blueprint('rate_api_bp', __name__)
 

--- a/web/web/api/v1/rate.py
+++ b/web/web/api/v1/rate.py
@@ -1,0 +1,102 @@
+from flask import request, Blueprint
+from marshmallow import ValidationError
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
+from .response_wrapper import ApiResponseWrapper
+from web.database import db
+from web.models.rate import Rate, RateSchema
+
+rate_api_bp = Blueprint('rate_api_bp', __name__)
+
+
+@rate_api_bp.route('/rates', methods=['GET'])
+def get_rates():
+    '''
+    Retrieves all rate objects
+    '''
+    arw = ApiResponseWrapper()
+
+    rates = Rate.query.all()
+    rate_schema = RateSchema()
+    results = rate_schema.dump(rates, many=True)
+
+    return arw.to_json(results)
+
+
+@rate_api_bp.route('/rate/<int:rate_id>', methods=['GET'])
+def show_rate_info(rate_id):
+    '''
+    Retrieves one rate object
+    '''
+    arw = ApiResponseWrapper()
+    rate_schema = RateSchema()
+
+    try:
+        rate = Rate.query.filter_by(rate_id=rate_id).one()
+
+    except (MultipleResultsFound, NoResultFound):
+        arw.add_errors('No result found or multiple results found')
+
+    if arw.has_errors():
+        return arw.to_json(None, 400)
+
+    results = rate_schema.dump(rate)
+
+    return arw.to_json(results)
+
+
+@rate_api_bp.route('/rate/<int:rate_id>', methods=['PUT'])
+def modify_rate(rate_id):
+    '''
+    Updates one rate object in database
+    '''
+    arw = ApiResponseWrapper()
+    rate_schema = RateSchema(exclude=['rate_id'])
+    modified_rate = request.get_json()
+
+    try:
+        modified_rate = rate_schema.load(modified_rate, session=db.session)
+        db.session.commit()
+
+    except ValidationError as ve:
+        arw.add_errors(ve.messages)
+
+    except IntegrityError:
+        arw.add_errors('Integrity error')
+
+    if arw.has_errors():
+        db.session.rollback()
+        return arw.to_json(None, 400)
+
+    results = rate_schema.dump(modified_rate, many=True)
+
+    return arw.to_json(results)
+
+
+@rate_api_bp.route('/rate', methods=['POST'])
+def add_rates():
+    '''
+    Adds new rate object to database
+    '''
+
+    arw = ApiResponseWrapper()
+    rate_schema = RateSchema(exclude=['rate_id'])
+    new_rate = request.get_json()
+
+    try:
+        new_rate = rate_schema.load(new_rate, session=db.session)
+        db.session.add(new_rate)
+        db.session.commit()
+
+    except ValidationError as ve:
+        arw.add_errors(ve.messages)
+
+    except IntegrityError:
+        arw.add_errors('Integrity error')
+
+    if arw.has_errors():
+        db.session.rollback()
+        return arw.to_json(None, 400)
+
+    results = RateSchema().dump(new_rate)
+    return arw.to_json(results)

--- a/web/web/api/v1/rate.py
+++ b/web/web/api/v1/rate.py
@@ -52,7 +52,7 @@ def modify_rate(rate_id):
     Updates one rate object in database
     '''
     arw = ApiResponseWrapper()
-    rate_schema = RateSchema(exclude=['rate_id'])
+    rate_schema = RateSchema()
     modified_rate = request.get_json()
 
     try:
@@ -69,7 +69,7 @@ def modify_rate(rate_id):
         db.session.rollback()
         return arw.to_json(None, 400)
 
-    results = rate_schema.dump(modified_rate, many=True)
+    results = rate_schema.dump(modified_rate)
 
     return arw.to_json(results)
 

--- a/web/web/api/v1/service_location.py
+++ b/web/web/api/v1/service_location.py
@@ -90,8 +90,7 @@ def modify_service_location(service_location_id):
         db.session.rollback()
         return arw.to_json(None, 400)
 
-    results = service_location_schema.dump(modified_service_location,
-                                           many=True)
+    results = service_location_schema.dump(modified_service_location)
 
     return arw.to_json(results)
 

--- a/web/web/api/v1/utility.py
+++ b/web/web/api/v1/utility.py
@@ -51,7 +51,7 @@ def modify_utility():
     Updates one utility object in database
     '''
     arw = ApiResponseWrapper()
-    utility_schema = UtilitySchema(exclude=['utility_id'])
+    utility_schema = UtilitySchema()
     modified_utility = request.get_json()
 
     try:

--- a/web/web/api/v1/utility.py
+++ b/web/web/api/v1/utility.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, request
 from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from .response_wrapper import ApiResponseWrapper
 from web.database import db
 from web.models.utility import Utility, UtilitySchema
@@ -18,6 +19,57 @@ def get_utilities():
     utilities = Utility.query.all()
     utility_schema = UtilitySchema()
     results = utility_schema.dump(utilities, many=True)
+
+    return arw.to_json(results)
+
+
+@utility_api_bp.route('/utility/<int:utility_id>', methods=['GET'])
+def show_utility_info(utility_id):
+    '''
+    Retrieves one utility object
+    '''
+    arw = ApiResponseWrapper()
+    utility_schema = UtilitySchema()
+
+    try:
+        utility = Utility.query.filter_by(utility_id=utility_id).one()
+
+    except (MultipleResultsFound, NoResultFound):
+        arw.add_errors('No result found or multiple results found')
+
+    if arw.has_errors():
+        return arw.to_json(None, 400)
+
+    results = utility_schema.dump(utility)
+
+    return arw.to_json(results)
+
+
+@utility_api_bp.route('/utility/<int:utility_id>', methods=['PUT'])
+def modify_utility():
+    '''
+    Updates one utility object in database
+    '''
+    arw = ApiResponseWrapper()
+    utility_schema = UtilitySchema(exclude=['utility_id'])
+    modified_utility = request.get_json()
+
+    try:
+        modified_utility = utility_schema.load(modified_utility,
+                                               session=db.session)
+        db.session.commit()
+
+    except ValidationError as ve:
+        arw.add_errors(ve.messages)
+
+    except IntegrityError:
+        arw.add_errors('Integrity error')
+
+    if arw.has_errors():
+        db.session.rollback()
+        return arw.to_json(None, 400)
+
+    results = utility_schema.dump(modified_utility, many=True)
 
     return arw.to_json(results)
 

--- a/web/web/api/v1/utility.py
+++ b/web/web/api/v1/utility.py
@@ -46,7 +46,7 @@ def show_utility_info(utility_id):
 
 
 @utility_api_bp.route('/utility/<int:utility_id>', methods=['PUT'])
-def modify_utility():
+def modify_utility(utility_id):
     '''
     Updates one utility object in database
     '''
@@ -69,7 +69,7 @@ def modify_utility():
         db.session.rollback()
         return arw.to_json(None, 400)
 
-    results = utility_schema.dump(modified_utility, many=True)
+    results = utility_schema.dump(modified_utility)
 
     return arw.to_json(results)
 

--- a/web/web/models/meter.py
+++ b/web/web/models/meter.py
@@ -189,8 +189,9 @@ class MeterSchema(SQLAlchemyAutoSchema):
         return MeterInterval.get_interval_coverage(coverage)
 
     def get_user_id(self, obj):
-        user = obj.service_location.address.user
-        return user.id
+        if obj.service_location.address.user:
+            return obj.service_location.address.user
+        return
 
     class Meta:
         model = Meter

--- a/web/web/models/meter_interval.py
+++ b/web/web/models/meter_interval.py
@@ -76,3 +76,14 @@ class MeterIntervalSchema(SQLAlchemyAutoSchema):
         model = MeterInterval
         load_instance = True
         include_fk = True
+
+##########################
+### MARSHMALLOW SCHEMA ###
+##########################
+
+
+class RateSchema(SQLAlchemyAutoSchema):
+    class Meta:
+        model = Rate
+        load_instance = True
+        include_fk = True

--- a/web/web/models/meter_interval.py
+++ b/web/web/models/meter_interval.py
@@ -77,10 +77,8 @@ class MeterIntervalSchema(SQLAlchemyAutoSchema):
         load_instance = True
         include_fk = True
 
-##########################
-### MARSHMALLOW SCHEMA ###
-##########################
-
+# marshmallow errors out if RateSchema is declared on models/rate.py
+# requires meter_interval to be initialized before RateSchema is declared
 
 class RateSchema(SQLAlchemyAutoSchema):
     class Meta:

--- a/web/web/models/rate.py
+++ b/web/web/models/rate.py
@@ -1,3 +1,4 @@
+from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from web.database import (
     db,
     Model,
@@ -24,3 +25,15 @@ class Rate(Model):
 
     # Relationships
     meter_intervals = relationship('MeterInterval', backref=db.backref('rate'))
+
+##########################
+### MARSHMALLOW SCHEMA ###
+##########################
+
+
+class RateSchema(SQLAlchemyAutoSchema):
+    class Meta:
+        model = Rate
+        include_fk = True
+        load_instance = True
+        transient = True

--- a/web/web/models/rate.py
+++ b/web/web/models/rate.py
@@ -25,15 +25,3 @@ class Rate(Model):
 
     # Relationships
     meter_intervals = relationship('MeterInterval', backref=db.backref('rate'))
-
-##########################
-### MARSHMALLOW SCHEMA ###
-##########################
-
-
-class RateSchema(SQLAlchemyAutoSchema):
-    class Meta:
-        model = Rate
-        include_fk = True
-        load_instance = True
-        transient = True


### PR DESCRIPTION
This PR fixes a few bugs on the market code testing side. Created rates API to add new rates to TESS DB. Added additional endpoints for more functionality. Fixed a couple errors with put methods that had many=True. Rate marshmallow schema had to be declared on meter_interval as it errors out if declared before meter_interval table is configured due to the relationship. Removed a typo (extra slash) on /pvs and /meters. Allowed meter marshmallow schema to return null for user_id if it doesn't exist to enable market testing without additional user set-up. 