### PR TITLE
power pages updates

### DIFF
--- a/web/web/api/v1/power.py
+++ b/web/web/api/v1/power.py
@@ -37,8 +37,8 @@ def get_power_system_load():
 
     results = {
         'labels': date_time_range,
-        'one': [getRandomNumber() for _ in range(0, value_range)],
-        'two': [getRandomNumber() for _ in range(0, value_range)]
+        'one': [],
+        'two': []
     }
 
     return arw.to_json(results)
@@ -53,11 +53,11 @@ def get_resources_load():
     value_range = 3
     results = {
         'datasets': {
-            'battery': [getRandomNumber() for _ in range(0, value_range)],
-            'charger': [getRandomNumber() for _ in range(0, value_range)],
-            'pv': [getRandomNumber() for _ in range(0, value_range)],
-            'hvac': [getRandomNumber() for _ in range(0, value_range)],
-            'hotWater': [getRandomNumber() for _ in range(0, value_range)]
+            'battery': [],
+            'charger': [],
+            'pv': [],
+            'hvac': [],
+            'hotWater': []
         },
         'groupedDataset': {
             'unavailable': [],

--- a/web/web/power_dispatch/static/actions.js
+++ b/web/web/power_dispatch/static/actions.js
@@ -34,7 +34,7 @@ export function storageSystemLoadDataUpdated(data) {
     };
 }
 
-export function getResourcesData() {
+export function getCapacityResourcesData() {
     return dispatch => {
         api.get('power/resources', (response) => {
             dispatch(capacityResourcesDataUpdated(response.results.data));
@@ -44,9 +44,40 @@ export function getResourcesData() {
     }
 }
 
+export function getStorageResourcesData() {
+    return dispatch => {
+        api.get('power/resources', (response) => {
+            dispatch(storageResourcesDataUpdated(response.results.data));
+        }, (error) => {
+            console.warn(error);
+        });
+    }
+}
+
 export function capacityResourcesDataUpdated(data) {
     return {
         type: 'CAPACITY_RESOURCES_DATA_UPDATED',
+        data
+    };
+}
+
+export function storageResourcesDataUpdated(data) {
+    return {
+        type: 'STORAGE_RESOURCES_DATA_UPDATED',
+        data
+    };
+}
+
+
+export function saveForm(data) {
+    return dispatch => {
+        dispatch(saveFormUpdated(data));
+    };
+}
+
+export function saveFormUpdated(data) {
+    return {
+        type: 'SAVE_FORM_DATA',
         data
     };
 }

--- a/web/web/power_dispatch/static/actions.js
+++ b/web/web/power_dispatch/static/actions.js
@@ -68,7 +68,6 @@ export function storageResourcesDataUpdated(data) {
     };
 }
 
-
 export function saveForm(data) {
     return dispatch => {
         dispatch(saveFormUpdated(data));

--- a/web/web/power_dispatch/static/capacity.js
+++ b/web/web/power_dispatch/static/capacity.js
@@ -119,11 +119,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Night</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.night}
-                                        onChange={(e) =>
-                                            this.update("night", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.night}
+                                            onChange={(e) =>
+                                                this.update("night", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
@@ -211,11 +211,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Between</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.betweenStart}
-                                        onChange={(e) =>
-                                            this.update("betweenStart", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.betweenStart}
+                                            onChange={(e) =>
+                                                this.update("betweenStart", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-input">

--- a/web/web/power_dispatch/static/capacity.js
+++ b/web/web/power_dispatch/static/capacity.js
@@ -14,7 +14,24 @@ import '@rmwc/switch/styles';
 import '@rmwc/button/styles';
 import '@rmwc/textfield/styles';
 
+
 class Capacity extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            day: "",
+            night: "",
+            yellowAlarm: "",
+            redAlarm: "",
+            capacityBounds: "",
+            resourcesDepletion: "",
+            betweenStart: "",
+            betweenEnd: "",
+            gridToHome: "",
+            homeToGrid: ""
+        };
+    }
+
     componentDidMount() {
         // if a user decides to navigate back and forth through the
         // browser arrows, the menu selection won't update accordingly,
@@ -22,11 +39,17 @@ class Capacity extends React.Component {
         // not great since the component shouldn't care about the menu
         this.props.dispatch(selectMenuOption('power-dispatch-capacity'));
         this.props.dispatch(action.getCapacitySystemLoadData());
-        this.props.dispatch(action.getResourcesData());
+        this.props.dispatch(action.getCapacityResourcesData());
+        this.setState(this.props.formData);
+    }
+
+    update = (field, event) => {
+        this.setState({ [field]: event.currentTarget.value });
     }
 
     render() {
-        const { resourcesData, systemLoadData } = this.props;
+        // debugger;
+        const { resourcesData, systemLoadData, formData } = this.props;
         return (
             <div className="power-dispatch-container">
                 <div className="power-dispatch-margin-fix">
@@ -56,8 +79,8 @@ class Capacity extends React.Component {
                                     id="pd-capacity-resources-chart"
                                     xTitle=""
                                     yTitle=""
-                                    datasets={this.props.resourcesData.datasets}
-                                    finalDataSet={this.props.resourcesData.groupedDataset}
+                                    datasets={resourcesData.datasets}
+                                    finalDataSet={resourcesData.groupedDataset}
                                     chartTitle="Resources in the System"
                                     chartSubtitle="" />
                                 : null
@@ -76,14 +99,26 @@ class Capacity extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Day</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.day}
+                                        onChange={(e) =>
+                                            this.update("day", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Night</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.night}
+                                        onChange={(e) =>
+                                            this.update("night", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
                                 </div>
@@ -96,14 +131,26 @@ class Capacity extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Yellow Alarm</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.yellowAlarm}
+                                        onChange={(e) =>
+                                            this.update("yellowAlarm", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Red Alarm</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.redAlarm}
+                                        onChange={(e) =>
+                                            this.update("redAlarm", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
                                 </div>
@@ -116,14 +163,26 @@ class Capacity extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Capacity Bounds</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.capacityBounds}
+                                        onChange={(e) =>
+                                            this.update("capacityBounds", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">kW</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Resource Depletion (Battery)</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.resourcesDepletion}
+                                        onChange={(e) =>
+                                            this.update("resourcesDepletion", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">hour(s)</div>
                                 </div>
@@ -133,12 +192,10 @@ class Capacity extends React.Component {
                             <div className="pd-form-button-container">
                                 <Button
                                     label="SET"
-                                    onClick={this.addNewRow}
                                     outlined />
                             </div>
                         </div>
-
-                        <div className="pd-form-container">
+                        <div className="pd-advanced-form-container">
                             <div className="pd-form-title">
                                 <h3>Advanced Control</h3>
                             </div>
@@ -147,16 +204,34 @@ class Capacity extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Between</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined type="time" />
+                                        <TextField outlined
+                                        value={this.state.betweenStart}
+                                        onChange={(e) =>
+                                            this.update("betweenStart", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined type="time" />
+                                        <TextField outlined
+                                        value={this.state.betweenEnd}
+                                        onChange={(e) =>
+                                            this.update("betweenEnd", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Grid to Home Constraint</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.gridToHome}
+                                        onChange={(e) =>
+                                            this.update("gridToHome", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
@@ -168,7 +243,13 @@ class Capacity extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Home to Grid Constraint</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.homeToGrid}
+                                        onChange={(e) =>
+                                            this.update("homeToGrid", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
@@ -176,6 +257,12 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-unit second-unit">
                                         <Switch>On/Off</Switch>
                                     </div>
+                                </div>
+                                <hr />
+                                <div className="pd-form-button-container">
+                                    <Button
+                                        label="SET"
+                                        outlined />
                                 </div>
                             </div>
                         </div>
@@ -187,7 +274,8 @@ class Capacity extends React.Component {
 }
 const ConnectedCapacity = connect(state => ({
     systemLoadData: state.capacity.systemLoadData,
-    resourcesData: state.capacity.resourcesData
+    resourcesData: state.capacity.resourcesData,
+    formData: state.formState.formData
 }))(Capacity);
 
 const capacityElement = (

--- a/web/web/power_dispatch/static/capacity.js
+++ b/web/web/power_dispatch/static/capacity.js
@@ -28,7 +28,9 @@ class Capacity extends React.Component {
             betweenStart: "",
             betweenEnd: "",
             gridToHome: "",
-            homeToGrid: ""
+            gridToHomeSwitch: false,
+            homeToGrid: "",
+            homeToGridSwitch: false
         };
     }
 
@@ -47,8 +49,12 @@ class Capacity extends React.Component {
         this.setState({ [field]: event.currentTarget.value });
     }
 
+    updateSwitch = (field, event) => {
+        this.setState({ [field]: !!event.currentTarget.checked});
+        this.props.dispatch(action.saveForm(this.state));
+    }
+
     render() {
-        // debugger;
         const { resourcesData, systemLoadData, formData } = this.props;
         return (
             <div className="power-dispatch-container">
@@ -100,11 +106,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Day</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.day}
-                                        onChange={(e) =>
-                                            this.update("day", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.day}
+                                            onChange={(e) =>
+                                                this.update("day", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
@@ -132,11 +138,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Yellow Alarm</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.yellowAlarm}
-                                        onChange={(e) =>
-                                            this.update("yellowAlarm", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.yellowAlarm}
+                                            onChange={(e) =>
+                                                this.update("yellowAlarm", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
@@ -145,11 +151,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Red Alarm</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.redAlarm}
-                                        onChange={(e) =>
-                                            this.update("redAlarm", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.redAlarm}
+                                            onChange={(e) =>
+                                                this.update("redAlarm", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
@@ -164,11 +170,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Capacity Bounds</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.capacityBounds}
-                                        onChange={(e) =>
-                                            this.update("capacityBounds", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.capacityBounds}
+                                            onChange={(e) =>
+                                                this.update("capacityBounds", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">kW</div>
@@ -177,11 +183,11 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Resource Depletion (Battery)</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.resourcesDepletion}
-                                        onChange={(e) =>
-                                            this.update("resourcesDepletion", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.resourcesDepletion}
+                                            onChange={(e) =>
+                                                this.update("resourcesDepletion", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">hour(s)</div>
@@ -214,11 +220,11 @@ class Capacity extends React.Component {
                                     </div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.betweenEnd}
-                                        onChange={(e) =>
-                                            this.update("betweenEnd", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.betweenEnd}
+                                            onChange={(e) =>
+                                                this.update("betweenEnd", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                 </div>
@@ -226,36 +232,44 @@ class Capacity extends React.Component {
                                     <div className="pd-form-element-label">Grid to Home Constraint</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.gridToHome}
-                                        onChange={(e) =>
-                                            this.update("gridToHome", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.gridToHome}
+                                            onChange={(e) =>
+                                                this.update("gridToHome", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
                                     </div>
                                     <div className="pd-form-element-unit second-unit">
-                                        <Switch>On/Off</Switch>
+                                        <Switch
+                                            label="Off/On"
+                                            checked={this.state.gridToHomeSwitch}
+                                            onChange={e => this.updateSwitch("gridToHomeSwitch", e)}
+                                        />
                                     </div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Home to Grid Constraint</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.homeToGrid}
-                                        onChange={(e) =>
-                                            this.update("homeToGrid", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.homeToGrid}
+                                            onChange={(e) =>
+                                                this.update("homeToGrid", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
                                     </div>
                                     <div className="pd-form-element-unit second-unit">
-                                        <Switch>On/Off</Switch>
+                                        <Switch
+                                            label="Off/On"
+                                            checked={this.state.homeToGridSwitch}
+                                            onChange={e => this.updateSwitch("homeToGridSwitch", e)}
+                                        />
                                     </div>
                                 </div>
                                 <hr />

--- a/web/web/power_dispatch/static/reducer.js
+++ b/web/web/power_dispatch/static/reducer.js
@@ -1,13 +1,14 @@
 const initialStorageState = {
     systemLoadData: [],
-    resourcesData: []
+    resourcesData: [],
+    formData: {}
 }
 
 export function storage(state = initialStorageState, action) {
-    switch (action.type) {        
+    switch (action.type) {
         case 'STORAGE_SYSTEM_LOAD_DATA_UPDATED':
             return { ...state, systemLoadData: action.data };
-        
+
         case 'STORAGE_RESOURCES_DATA_UPDATED':
             return { ...state, resourcesData: action.data };
 
@@ -18,17 +19,27 @@ export function storage(state = initialStorageState, action) {
 
 const initialCapacityState = {
     systemLoadData: [],
-    resourcesData: []
+    resourcesData: [],
+    formData: {}
 }
 
 export function capacity(state = initialCapacityState, action) {
-    switch (action.type) {        
+    switch (action.type) {
         case 'CAPACITY_SYSTEM_LOAD_DATA_UPDATED':
             return { ...state, systemLoadData: action.data };
-        
+
         case 'CAPACITY_RESOURCES_DATA_UPDATED':
             return { ...state, resourcesData: action.data };
 
+        default:
+            return state;
+    }
+}
+
+export function formState(state = initialStorageState, action) {
+    switch (action.type) {
+        case 'SAVE_FORM_DATA':
+            return { ...state, formData: action.data };
         default:
             return state;
     }

--- a/web/web/power_dispatch/static/resources.js
+++ b/web/web/power_dispatch/static/resources.js
@@ -58,7 +58,7 @@ class ResourcesChart extends React.Component {
 
             // The data for our dataset
             data: {
-                labels: ['Total', 'Battery', 'Chargers', 'PV', 'HVAC', 'Hot Water'],
+                labels: ['PV'],
 			    datasets: [
                     {
 				        label: 'Dispatched',

--- a/web/web/power_dispatch/static/storage.js
+++ b/web/web/power_dispatch/static/storage.js
@@ -28,7 +28,9 @@ class Storage extends React.Component {
             betweenStart: "",
             betweenEnd: "",
             gridToHome: "",
-            homeToGrid: ""
+            gridToHomeSwitch: false,
+            homeToGrid: "",
+            homeToGridSwitch: false
         };
     }
 
@@ -45,6 +47,11 @@ class Storage extends React.Component {
 
     update = (field, event) => {
         this.setState({ [field]: event.currentTarget.value });
+    }
+
+    updateSwitch = (field, event) => {
+        this.setState({ [field]: !!event.currentTarget.checked});
+        this.props.dispatch(action.saveForm(this.state));
     }
 
     render() {
@@ -236,7 +243,11 @@ class Storage extends React.Component {
                                         kW
                                     </div>
                                     <div className="pd-form-element-unit second-unit">
-                                        <Switch>On/Off</Switch>
+                                        <Switch
+                                            label="Off/On"
+                                            checked={this.state.gridToHomeSwitch}
+                                            onChange={e => this.updateSwitch("gridToHomeSwitch", e)}
+                                        />
                                     </div>
                                 </div>
                                 <div className="pd-form-row">
@@ -254,7 +265,11 @@ class Storage extends React.Component {
                                         kW
                                     </div>
                                     <div className="pd-form-element-unit second-unit">
-                                        <Switch>On/Off</Switch>
+                                        <Switch
+                                            label="Off/On"
+                                            checked={this.state.homeToGridSwitch}
+                                            onChange={e => this.updateSwitch("homeToGridSwitch", e)}
+                                        />
                                     </div>
                                 </div>
                                 <hr />

--- a/web/web/power_dispatch/static/storage.js
+++ b/web/web/power_dispatch/static/storage.js
@@ -15,22 +15,23 @@ import '@rmwc/button/styles';
 import '@rmwc/textfield/styles';
 
 
-const datasets = {
-    battery: [1,2,0],
-    charger: [5,7,0],
-    pv: [3,3,0],
-    hvac: [10,15,0],
-    hotWater: [12,1,0]
-};
-
-const finalDataSet = {
-    "unavailable": [],
-    "available": [],
-    "dispatched": []
-};
-
-
 class Storage extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            day: "",
+            night: "",
+            yellowAlarm: "",
+            redAlarm: "",
+            capacityBounds: "",
+            resourcesDepletion: "",
+            betweenStart: "",
+            betweenEnd: "",
+            gridToHome: "",
+            homeToGrid: ""
+        };
+    }
+
     componentDidMount() {
         // if a user decides to navigate back and forth through the
         // browser arrows, the menu selection won't update accordingly,
@@ -38,10 +39,16 @@ class Storage extends React.Component {
         // not great since the component shouldn't care about the menu
         this.props.dispatch(selectMenuOption('power-dispatch-storage'));
         this.props.dispatch(action.getStorageSystemLoadData());
+        this.props.dispatch(action.getStorageResourcesData());
+        this.setState(this.props.formData);
+    }
+
+    update = (field, event) => {
+        this.setState({ [field]: event.currentTarget.value });
     }
 
     render() {
-        const { systemLoadData } = this.props;
+        const { resourcesData, systemLoadData, formData } = this.props;
         return (
             <div className="power-dispatch-container">
                 <div className="power-dispatch-margin-fix">
@@ -63,15 +70,19 @@ class Storage extends React.Component {
                             }
                         </div>
                         <div className="pd-chart-resource">
-                            <ResourcesChart
-                                id="pd-capacity-resources-chart"
-                                xTitle=""
-                                yTitle=""
-                                datasets={datasets}
-                                finalDataSet={finalDataSet}
-                                hiddenDataSets={{dispatched: true}}
-                                chartTitle="Resources in the System"
-                                chartSubtitle="" />
+                            {
+                                // to check if data exists when calling <ResourcesChart>
+                                resourcesData.datasets
+                                ? <ResourcesChart
+                                    id="pd-capacity-resources-chart"
+                                    xTitle=""
+                                    yTitle=""
+                                    datasets={resourcesData.datasets}
+                                    finalDataSet={resourcesData.groupedDataset}
+                                    chartTitle="Resources in the System"
+                                    chartSubtitle="" />
+                                : null
+                            }
                         </div>
                     </div>
 
@@ -86,14 +97,26 @@ class Storage extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Day</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.day}
+                                        onChange={(e) =>
+                                            this.update("day", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Night</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.night}
+                                        onChange={(e) =>
+                                            this.update("night", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
                                 </div>
@@ -106,14 +129,26 @@ class Storage extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Yellow Alarm</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.yellowAlarm}
+                                        onChange={(e) =>
+                                            this.update("yellowAlarm", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Red Alarm</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.redAlarm}
+                                        onChange={(e) =>
+                                            this.update("redAlarm", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
                                 </div>
@@ -126,14 +161,26 @@ class Storage extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Capacity Bounds</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.capacityBounds}
+                                        onChange={(e) =>
+                                            this.update("capacityBounds", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">kW</div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Resource Depletion (Battery)</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.resourcesDepletion}
+                                        onChange={(e) =>
+                                            this.update("resourcesDepletion", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit">hour(s)</div>
                                 </div>
@@ -147,8 +194,7 @@ class Storage extends React.Component {
                                     outlined />
                             </div>
                         </div>
-
-                        <div className="pd-form-container">
+                        <div className="pd-advanced-form-container">
                             <div className="pd-form-title">
                                 <h3>Advanced Control</h3>
                             </div>
@@ -157,16 +203,34 @@ class Storage extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Between</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined type="time" />
+                                        <TextField outlined
+                                        value={this.state.betweenStart}
+                                        onChange={(e) =>
+                                            this.update("betweenStart", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined type="time" />
+                                        <TextField outlined
+                                        value={this.state.betweenEnd}
+                                        onChange={(e) =>
+                                            this.update("betweenEnd", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                 </div>
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Grid to Home Constraint</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.gridToHome}
+                                        onChange={(e) =>
+                                            this.update("gridToHome", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
@@ -178,7 +242,13 @@ class Storage extends React.Component {
                                 <div className="pd-form-row">
                                     <div className="pd-form-element-label">Home to Grid Constraint</div>
                                     <div className="pd-form-element-input">
-                                        <TextField outlined />
+                                        <TextField outlined
+                                        value={this.state.homeToGrid}
+                                        onChange={(e) =>
+                                            this.update("homeToGrid", e)
+                                        }
+                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                        />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
                                         kW
@@ -186,6 +256,12 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-unit second-unit">
                                         <Switch>On/Off</Switch>
                                     </div>
+                                </div>
+                                <hr />
+                                <div className="pd-form-button-container">
+                                    <Button
+                                        label="SET"
+                                        outlined />
                                 </div>
                             </div>
                         </div>
@@ -198,7 +274,8 @@ class Storage extends React.Component {
 
 const ConnectedStorage = connect(state => ({
     systemLoadData: state.storage.systemLoadData,
-    resourcesData: state.storage.resourcesData
+    resourcesData: state.storage.resourcesData,
+    formData: state.formState.formData
 }))(Storage);
 
 const storageElement = (

--- a/web/web/power_dispatch/static/storage.js
+++ b/web/web/power_dispatch/static/storage.js
@@ -75,6 +75,7 @@ class Storage extends React.Component {
                                 :
                                 null
                             }
+
                         </div>
                         <div className="pd-chart-resource">
                             {
@@ -105,11 +106,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Day</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.day}
-                                        onChange={(e) =>
-                                            this.update("day", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.day}
+                                            onChange={(e) =>
+                                                this.update("day", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
@@ -118,11 +119,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Night</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.night}
-                                        onChange={(e) =>
-                                            this.update("night", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.night}
+                                            onChange={(e) =>
+                                                this.update("night", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">MW</div>
@@ -137,11 +138,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Yellow Alarm</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.yellowAlarm}
-                                        onChange={(e) =>
-                                            this.update("yellowAlarm", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.yellowAlarm}
+                                            onChange={(e) =>
+                                                this.update("yellowAlarm", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
@@ -150,11 +151,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Red Alarm</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.redAlarm}
-                                        onChange={(e) =>
-                                            this.update("redAlarm", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.redAlarm}
+                                            onChange={(e) =>
+                                                this.update("redAlarm", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">%</div>
@@ -169,11 +170,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Capacity Bounds</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.capacityBounds}
-                                        onChange={(e) =>
-                                            this.update("capacityBounds", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.capacityBounds}
+                                            onChange={(e) =>
+                                                this.update("capacityBounds", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">kW</div>
@@ -182,11 +183,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Resource Depletion (Battery)</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.resourcesDepletion}
-                                        onChange={(e) =>
-                                            this.update("resourcesDepletion", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.resourcesDepletion}
+                                            onChange={(e) =>
+                                                this.update("resourcesDepletion", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit">hour(s)</div>
@@ -197,7 +198,6 @@ class Storage extends React.Component {
                             <div className="pd-form-button-container">
                                 <Button
                                     label="SET"
-                                    onClick={this.addNewRow}
                                     outlined />
                             </div>
                         </div>
@@ -211,20 +211,20 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Between</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.betweenStart}
-                                        onChange={(e) =>
-                                            this.update("betweenStart", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.betweenStart}
+                                            onChange={(e) =>
+                                                this.update("betweenStart", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.betweenEnd}
-                                        onChange={(e) =>
-                                            this.update("betweenEnd", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.betweenEnd}
+                                            onChange={(e) =>
+                                                this.update("betweenEnd", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                 </div>
@@ -232,11 +232,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Grid to Home Constraint</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.gridToHome}
-                                        onChange={(e) =>
-                                            this.update("gridToHome", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.gridToHome}
+                                            onChange={(e) =>
+                                                this.update("gridToHome", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">
@@ -254,11 +254,11 @@ class Storage extends React.Component {
                                     <div className="pd-form-element-label">Home to Grid Constraint</div>
                                     <div className="pd-form-element-input">
                                         <TextField outlined
-                                        value={this.state.homeToGrid}
-                                        onChange={(e) =>
-                                            this.update("homeToGrid", e)
-                                        }
-                                        onBlur={this.props.dispatch(action.saveForm(this.state))}
+                                            value={this.state.homeToGrid}
+                                            onChange={(e) =>
+                                                this.update("homeToGrid", e)
+                                            }
+                                            onBlur={this.props.dispatch(action.saveForm(this.state))}
                                         />
                                     </div>
                                     <div className="pd-form-element-unit first-unit">

--- a/web/web/static/css/base.css
+++ b/web/web/static/css/base.css
@@ -43,11 +43,11 @@ ul, li {
     /* Set rules to fill background */
     min-height: 100%;
     min-width: 1024px;
-        
+
     /* Set up proportionate scaling */
     width: 100%;
     height: auto;
-        
+
     /* Set up positioning */
     position: fixed;
     top: 0;
@@ -65,11 +65,11 @@ ul, li {
     /* Set rules to fill background */
     min-height: 100%;
     min-width: 1024px;
-        
+
     /* Set up proportionate scaling */
     width: 100%;
     height: auto;
-        
+
     /* Set up positioning */
     position: fixed;
     top: 0;
@@ -97,7 +97,7 @@ ul, li {
 }
 .login-form-container input,
 .create-account-form-container input,
-.login-form-container button { 
+.login-form-container button {
     width: 400px;
 }
 
@@ -220,6 +220,9 @@ ul, li {
 }
 .pd-form-element-input > label{
     height: 40px;
+}
+.pd-advanced-form-container{
+    padding-top: 50px;
 }
 
 /* MARKETS */

--- a/web/web/static/js/config/base_reducer.js
+++ b/web/web/static/js/config/base_reducer.js
@@ -7,7 +7,7 @@ import constraints from "../../../constraints/static/reducer";
 import costRevenue from "../../../cost_revenue/static/reducer";
 import userSettings from "../../../user_settings/static/reducer";
 import notifications from "../../../notifications/static/reducer";
-import { storage, capacity } from "../../../power_dispatch/static/reducer";
+import { storage, capacity, formState } from "../../../power_dispatch/static/reducer";
 
 const appReducer = combineReducers({
     auth,
@@ -18,6 +18,7 @@ const appReducer = combineReducers({
     notifications,
     storage,
     capacity,
+    formState,
     userSettings,
     drawerNavigationMenu,
 });


### PR DESCRIPTION
- Charts are blank as no data is received | random data generated has been removed
- Power/storage and power/capacity forms share the same state when switching between pages
- button added to advanced options in the form and advanced options has been slightly pushed down via css changes
![Screen Shot 2021-02-10 at 3 50 36 PM](https://user-images.githubusercontent.com/29395688/107588314-4de5ea80-6bb8-11eb-85ba-4a5c9c600716.png)


