### PR TITLE
meter api call issue addressed

### DIFF
--- a/web/web/models/meter.py
+++ b/web/web/models/meter.py
@@ -4,6 +4,7 @@ from sqlalchemy.types import TIMESTAMP
 from sqlalchemy import text, func
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from marshmallow import fields, ValidationError
+from flask import jsonify
 
 from web.models.channel import Channel, ChannelSchema
 from web.models.meter_interval import MeterInterval
@@ -72,7 +73,7 @@ class Meter(Model):
 
     # Methods
     def get_interval_count(self, start, end):
-        '''Takes in start and end ISO8601 times, 
+        '''Takes in start and end ISO8601 times,
             returns the interval count (integer) between start / end times, inclusively'''
 
         self_intervals = self.meter_intervals
@@ -176,8 +177,12 @@ class MeterSchema(SQLAlchemyAutoSchema):
         return MeterInterval.get_interval_coverage(coverage)
 
     def get_user_id(self, obj):
-        if obj.service_location.address.user:
-            return obj.service_location.address.user
+        users = obj.service_location.address.users
+        if users:
+            user_ids = []
+            for user in users:
+                user_ids.append(vars(user)["id"])
+            return user_ids
         return
 
     class Meta:

--- a/web/web/models/meter.py
+++ b/web/web/models/meter.py
@@ -4,7 +4,6 @@ from sqlalchemy.types import TIMESTAMP
 from sqlalchemy import text, func
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from marshmallow import fields, ValidationError
-from flask import jsonify
 
 from web.models.channel import Channel, ChannelSchema
 from web.models.meter_interval import MeterInterval

--- a/web/web/models/meter.py
+++ b/web/web/models/meter.py
@@ -178,11 +178,9 @@ class MeterSchema(SQLAlchemyAutoSchema):
     def get_user_id(self, obj):
         users = obj.service_location.address.users
         if users:
-            user_ids = []
-            for user in users:
-                user_ids.append(vars(user)["id"])
+            user_ids = [ user.id for user in users ]
             return user_ids
-        return
+        return []
 
     class Meta:
         model = Meter


### PR DESCRIPTION
"meters" get request works now.

sample response:
{
    "errors": [],
    "results": {
        "count": 1,
        "data": [
            {
                "alternate_meter_id": "1",
                "channels": [],
                "created_at": "2021-02-11T11:27:48",
                "feeder": "asdf",
                "home_hub_id": 1,
                "interval_count": 0,
                "interval_coverage": [],
                "is_active": true,
                "is_archived": false,
                "map_location": "RWC",
                "meter_id": 1,
                "meter_type": "Commercial",
                "postal_code": "94065",
                "rates": [
                    "rate one"
                ],
                "service_location_id": 1,
                "substation": "asdf",
                "transformer_id": 1,
                "updated_at": "2021-02-11T11:27:48",
                "user_id": [
                    1,
                    2,
                    3
                ],
                "utility_id": 1
            }
        ],
        "detail": ""
    }
}