### PR TITLE
Alerts update data

### DIFF
--- a/web/web/alerts/static/actions.js
+++ b/web/web/alerts/static/actions.js
@@ -1,4 +1,5 @@
 import { api } from '../../static/js/network_client';
+import { createPopup } from '../../static/js/helpers';
 
 function updateFetchedAlerts(data) {
     return {
@@ -12,7 +13,7 @@ export function getAlerts() {
         api.get('alerts', (response) => {
             dispatch(updateFetchedAlerts(response.results.data));
         }, (error) => {
-            console.warn(error);
+            createPopup('Check API connection')
         })
     }
 }
@@ -22,7 +23,7 @@ export function updateAlerts(data) {
         api.put('alert', { json: { ...data } }, (response) => {
             dispatch(getAlerts());
         }, (error) => {
-            console.warn(error);
+            createPopup('Check API connection')
         })
     }
 }

--- a/web/web/alerts/static/alerts.js
+++ b/web/web/alerts/static/alerts.js
@@ -26,15 +26,25 @@ class Alerts extends React.Component {
         this.setState({inputValueReferences: refs});
     }
 
-    handleStatusChange = (e, alert, resValue) => {
-        // add resolution change to this function or create a new one
+    handleResolutionChange = (e, alert) => {
+        this.props.dispatch(action.updateAlerts({
+            "alert_id" : alert.alert_id,
+            "alert_type_id" : alert.alert_type_id,
+            "assigned_to" : alert.assigned_to,
+            "description" : alert.description,
+            "status" : alert.status,
+            "resolution" : e.target.value
+        }))
+    }
+
+    handleStatusChange = (e, alert) => {
         this.props.dispatch(action.updateAlerts({
             "alert_id" : alert.alert_id,
             "alert_type_id" : alert.alert_type_id,
             "assigned_to" : alert.assigned_to,
             "description" : alert.description,
             "status" : e.currentTarget.value,
-            "resolution" : resValue
+            "resolution" : alert.resolution
         }))
     }
 
@@ -80,12 +90,13 @@ class Alerts extends React.Component {
                         defaultValue={item.status}
                         enhanced
                         options={["open", "pending", "resolved"]}
-                        onChange={(e) => this.handleStatusChange(e, item, resolutionValue)}
+                        onChange={(e) => this.handleStatusChange(e, item)}
                     />
                     <DT.DataTableCell>{item.assigned_to}</DT.DataTableCell>
                     <DT.DataTableCell>
                         <TextField
                             onChange={(e) => this.handleChange(e, index)}
+                            onBlur={(e) => this.handleResolutionChange(e, item)}
                             outlined={false}
                             fullwidth={true}
                             align="start"

--- a/web/web/cost_revenue/static/cost_revenue_charts.js
+++ b/web/web/cost_revenue/static/cost_revenue_charts.js
@@ -21,14 +21,14 @@ class CostRevenueChart extends React.Component {
                         fill: false,
                         backgroundColor: 'rgb(255, 99, 132)',
                         borderColor: 'rgb(255, 99, 132)',
-                        data: [0, 10, 5, 2, 20, 30, 45]
+                        data: []
                     },
                     {
                         label: 'My Second dataset',
                         fill: false,
                         backgroundColor: 'rgb(55, 99, 255)',
                         borderColor: 'rgb(55, 99, 255)',
-                        data: [0, 50, 3, 20, 20, 20, 15]
+                        data: []
                     }
                 ]
             },

--- a/web/web/markets/static/auction.js
+++ b/web/web/markets/static/auction.js
@@ -21,14 +21,14 @@ class AuctionChart extends React.Component {
                         fill: false,
                         backgroundColor: 'rgb(255, 99, 132)',
                         borderColor: 'rgb(255, 99, 132)',
-                        data: [0, 10, 5, 2, 20, 30, 45]
+                        data: []
                     },
                     {
                         label: 'My Second dataset',
                         fill: false,
                         backgroundColor: 'rgb(55, 99, 255)',
                         borderColor: 'rgb(55, 99, 255)',
-                        data: [0, 50, 3, 20, 20, 20, 15]
+                        data: []
                     }
                 ]
             },

--- a/web/web/markets/static/auction_market.js
+++ b/web/web/markets/static/auction_market.js
@@ -19,17 +19,17 @@ class AuctionMarketChart extends React.Component {
                     {
                         label: 'Dataset 1',
                         backgroundColor: 'red',
-                        data: [1,2,3,4,5,6,7]
+                        data: []
                     },
                     {
                         label: 'Dataset 2',
                         backgroundColor: 'blue',
-                        data: [7,6,5,4,3,2,1]
+                        data: []
                     },
                     {
 				        label: 'Dataset 3',
 				        backgroundColor: 'green',
-                        data: [11,21,31,4,15,6,17]
+                        data: []
                     }
                 ]
             },

--- a/web/web/markets/static/historical.js
+++ b/web/web/markets/static/historical.js
@@ -21,14 +21,14 @@ class HistoricalChart extends React.Component {
                         fill: false,
                         backgroundColor: 'rgb(255, 99, 132)',
                         borderColor: 'rgb(255, 99, 132)',
-                        data: [0, 10, 5, 2, 20, 30, 45]
+                        data: []
                     },
                     {
                         label: 'My Second dataset',
                         fill: false,
                         backgroundColor: 'rgb(55, 99, 255)',
                         borderColor: 'rgb(55, 99, 255)',
-                        data: [0, 50, 3, 20, 20, 20, 15]
+                        data: []
                     }
                 ]
             },


### PR DESCRIPTION
This PR removes hard coded data from the markets and cost/revenue page. 

Handles API Call failure with a POPUp instead of console.warn on the Alerts page only. The rest of the handling of similar errors will be done in future PRs.

Allows resolution to be updated onBlur() on alerts table